### PR TITLE
Stylistic updates to the readme. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ For example: `2025-01-13_k-means_gpt4-naming_k=5_1900.json`
 
 ### Setting up the Visualization Setup
 Make sure you have Streamlit and other required dependencies.
-```shell 
+```console 
 pip install streamlit pandas numpy
 ```
 To run the visualization, run the code:
-```shell 
+```console 
 streamlit run app.py
 ```


### PR DESCRIPTION
Nit: Note adding the syntax type right after ``` leads to appropriate rendering (color-coding) of the keywords: 

<img width="447" alt="image" src="https://github.com/user-attachments/assets/6548b991-3fd6-440c-8a31-42c2a380353d" />


